### PR TITLE
Add basic Node.js API server

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,2 +1,7 @@
 # yikaidan.github.io
+
 yikaidan
+
+## Server
+
+A simple Node.js server is located in the `server/` directory. Run `npm install` and `npm start` inside that folder to start the API.

--- a/server/index.js
+++ b/server/index.js
@@ -1,0 +1,31 @@
+const express = require('express');
+const bodyParser = require('body-parser');
+
+const { sequelize } = require('./models');
+const customerRoutes = require('./routes/customers');
+const productRoutes = require('./routes/products');
+const orderRoutes = require('./routes/orders');
+const wechatRoutes = require('./routes/wechat');
+
+const app = express();
+app.use(bodyParser.json());
+
+app.use('/customers', customerRoutes);
+app.use('/products', productRoutes);
+app.use('/orders', orderRoutes);
+app.use('/wechat', wechatRoutes);
+
+const port = process.env.PORT || 3000;
+
+async function start() {
+  try {
+    await sequelize.sync();
+    app.listen(port, () => {
+      console.log(`Server listening on port ${port}`);
+    });
+  } catch (err) {
+    console.error('Unable to start server:', err);
+  }
+}
+
+start();

--- a/server/models/customer.js
+++ b/server/models/customer.js
@@ -1,0 +1,14 @@
+module.exports = (sequelize, DataTypes) => {
+  const Customer = sequelize.define('Customer', {
+    name: {
+      type: DataTypes.STRING,
+      allowNull: false
+    },
+    email: {
+      type: DataTypes.STRING,
+      allowNull: false,
+      unique: true
+    }
+  });
+  return Customer;
+};

--- a/server/models/index.js
+++ b/server/models/index.js
@@ -1,0 +1,18 @@
+const { Sequelize, DataTypes } = require('sequelize');
+const createCustomer = require('./customer');
+const createProduct = require('./product');
+const createOrder = require('./order');
+
+const DATABASE_URL = process.env.MYSQL_URI || 'mysql://user:pass@localhost:3306/app_db';
+const sequelize = new Sequelize(DATABASE_URL);
+
+const Customer = createCustomer(sequelize, DataTypes);
+const Product = createProduct(sequelize, DataTypes);
+const Order = createOrder(sequelize, DataTypes);
+
+Customer.hasMany(Order);
+Order.belongsTo(Customer);
+Product.hasMany(Order);
+Order.belongsTo(Product);
+
+module.exports = { sequelize, Customer, Product, Order };

--- a/server/models/order.js
+++ b/server/models/order.js
@@ -1,0 +1,15 @@
+module.exports = (sequelize, DataTypes) => {
+  const Order = sequelize.define('Order', {
+    quantity: {
+      type: DataTypes.INTEGER,
+      allowNull: false,
+      defaultValue: 1
+    },
+    status: {
+      type: DataTypes.STRING,
+      allowNull: false,
+      defaultValue: 'pending'
+    }
+  });
+  return Order;
+};

--- a/server/models/product.js
+++ b/server/models/product.js
@@ -1,0 +1,13 @@
+module.exports = (sequelize, DataTypes) => {
+  const Product = sequelize.define('Product', {
+    name: {
+      type: DataTypes.STRING,
+      allowNull: false
+    },
+    price: {
+      type: DataTypes.DECIMAL,
+      allowNull: false
+    }
+  });
+  return Product;
+};

--- a/server/package.json
+++ b/server/package.json
@@ -1,0 +1,14 @@
+{
+  "name": "yikandan-server",
+  "version": "1.0.0",
+  "description": "Basic CRUD API with WeChat pay callback",
+  "main": "index.js",
+  "scripts": {
+    "start": "node index.js"
+  },
+  "dependencies": {
+    "express": "^4.18.2",
+    "sequelize": "^6.35.1",
+    "mysql2": "^3.3.4"
+  }
+}

--- a/server/routes/customers.js
+++ b/server/routes/customers.js
@@ -1,0 +1,35 @@
+const express = require('express');
+const router = express.Router();
+const { Customer } = require('../models');
+
+router.get('/', async (req, res) => {
+  const customers = await Customer.findAll();
+  res.json(customers);
+});
+
+router.get('/:id', async (req, res) => {
+  const customer = await Customer.findByPk(req.params.id);
+  if (!customer) return res.status(404).end();
+  res.json(customer);
+});
+
+router.post('/', async (req, res) => {
+  const customer = await Customer.create(req.body);
+  res.status(201).json(customer);
+});
+
+router.put('/:id', async (req, res) => {
+  const customer = await Customer.findByPk(req.params.id);
+  if (!customer) return res.status(404).end();
+  await customer.update(req.body);
+  res.json(customer);
+});
+
+router.delete('/:id', async (req, res) => {
+  const customer = await Customer.findByPk(req.params.id);
+  if (!customer) return res.status(404).end();
+  await customer.destroy();
+  res.status(204).end();
+});
+
+module.exports = router;

--- a/server/routes/orders.js
+++ b/server/routes/orders.js
@@ -1,0 +1,35 @@
+const express = require('express');
+const router = express.Router();
+const { Order, Customer, Product } = require('../models');
+
+router.get('/', async (req, res) => {
+  const orders = await Order.findAll({ include: [Customer, Product] });
+  res.json(orders);
+});
+
+router.get('/:id', async (req, res) => {
+  const order = await Order.findByPk(req.params.id, { include: [Customer, Product] });
+  if (!order) return res.status(404).end();
+  res.json(order);
+});
+
+router.post('/', async (req, res) => {
+  const order = await Order.create(req.body);
+  res.status(201).json(order);
+});
+
+router.put('/:id', async (req, res) => {
+  const order = await Order.findByPk(req.params.id);
+  if (!order) return res.status(404).end();
+  await order.update(req.body);
+  res.json(order);
+});
+
+router.delete('/:id', async (req, res) => {
+  const order = await Order.findByPk(req.params.id);
+  if (!order) return res.status(404).end();
+  await order.destroy();
+  res.status(204).end();
+});
+
+module.exports = router;

--- a/server/routes/products.js
+++ b/server/routes/products.js
@@ -1,0 +1,35 @@
+const express = require('express');
+const router = express.Router();
+const { Product } = require('../models');
+
+router.get('/', async (req, res) => {
+  const products = await Product.findAll();
+  res.json(products);
+});
+
+router.get('/:id', async (req, res) => {
+  const product = await Product.findByPk(req.params.id);
+  if (!product) return res.status(404).end();
+  res.json(product);
+});
+
+router.post('/', async (req, res) => {
+  const product = await Product.create(req.body);
+  res.status(201).json(product);
+});
+
+router.put('/:id', async (req, res) => {
+  const product = await Product.findByPk(req.params.id);
+  if (!product) return res.status(404).end();
+  await product.update(req.body);
+  res.json(product);
+});
+
+router.delete('/:id', async (req, res) => {
+  const product = await Product.findByPk(req.params.id);
+  if (!product) return res.status(404).end();
+  await product.destroy();
+  res.status(204).end();
+});
+
+module.exports = router;

--- a/server/routes/wechat.js
+++ b/server/routes/wechat.js
@@ -1,0 +1,11 @@
+const express = require('express');
+const router = express.Router();
+
+// Simulated WeChat Pay callback handler
+router.post('/pay/callback', async (req, res) => {
+  console.log('Received WeChat Pay callback:', req.body);
+  // Here you would verify the signature and update order status
+  res.send('success');
+});
+
+module.exports = router;


### PR DESCRIPTION
## Summary
- create a new `server` directory for Node.js code
- implement CRUD routes for orders, products, and customers
- add WeChat Pay callback handler
- define Sequelize models for MySQL
- document server usage in README

## Testing
- `npm test` *(fails: Missing script)*

------
https://chatgpt.com/codex/tasks/task_e_6847760aeef48331815c895068651a14