### PR TITLE
Add initial miniprogram structure

### DIFF
--- a/miniprogram/app.js
+++ b/miniprogram/app.js
@@ -1,0 +1,5 @@
+App({
+  onLaunch() {
+    // App initialization
+  }
+})

--- a/miniprogram/app.json
+++ b/miniprogram/app.json
@@ -1,0 +1,10 @@
+{
+  "pages": [
+    "pages/createOrder/index",
+    "pages/orderList/index",
+    "pages/orderDetail/index"
+  ],
+  "window": {
+    "navigationBarTitleText": "Mini Program"
+  }
+}

--- a/miniprogram/app.wxss
+++ b/miniprogram/app.wxss
@@ -1,0 +1,1 @@
+/* Global styles */

--- a/miniprogram/pages/createOrder/index.js
+++ b/miniprogram/pages/createOrder/index.js
@@ -1,0 +1,4 @@
+Page({
+  data: {},
+  onLoad(options) {}
+})

--- a/miniprogram/pages/createOrder/index.wxml
+++ b/miniprogram/pages/createOrder/index.wxml
@@ -1,0 +1,1 @@
+<view>Create Order Page</view>

--- a/miniprogram/pages/createOrder/index.wxss
+++ b/miniprogram/pages/createOrder/index.wxss
@@ -1,0 +1,1 @@
+/* Create Order styles */

--- a/miniprogram/pages/orderDetail/index.js
+++ b/miniprogram/pages/orderDetail/index.js
@@ -1,0 +1,4 @@
+Page({
+  data: {},
+  onLoad(options) {}
+})

--- a/miniprogram/pages/orderDetail/index.wxml
+++ b/miniprogram/pages/orderDetail/index.wxml
@@ -1,0 +1,1 @@
+<view>Order Detail Page</view>

--- a/miniprogram/pages/orderDetail/index.wxss
+++ b/miniprogram/pages/orderDetail/index.wxss
@@ -1,0 +1,1 @@
+/* Order Detail styles */

--- a/miniprogram/pages/orderList/index.js
+++ b/miniprogram/pages/orderList/index.js
@@ -1,0 +1,4 @@
+Page({
+  data: {},
+  onLoad(options) {}
+})

--- a/miniprogram/pages/orderList/index.wxml
+++ b/miniprogram/pages/orderList/index.wxml
@@ -1,0 +1,1 @@
+<view>Order List Page</view>

--- a/miniprogram/pages/orderList/index.wxss
+++ b/miniprogram/pages/orderList/index.wxss
@@ -1,0 +1,1 @@
+/* Order List styles */

--- a/miniprogram/utils/README.md
+++ b/miniprogram/utils/README.md
@@ -1,0 +1,1 @@
+Utility functions for the mini program.


### PR DESCRIPTION
## Summary
- set up basic directory for a WeChat miniprogram
- add empty pages for create order, order list and order detail
- configure `app.js`, `app.json` and global styles

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68477609cc8c8331a697af5ee8872419