### PR TITLE
Add order creation form and list loading

### DIFF
--- a/miniprogram/pages/createOrder/index.js
+++ b/miniprogram/pages/createOrder/index.js
@@ -1,4 +1,37 @@
 Page({
-  data: {},
-  onLoad(options) {}
+  data: {
+    form: {
+      customer: '',
+      product: '',
+      quantity: 1,
+      amount: ''
+    }
+  },
+
+  onLoad() {},
+
+  onInput(e) {
+    const field = e.currentTarget.dataset.field
+    this.setData({
+      [`form.${field}`]: e.detail.value
+    })
+  },
+
+  onSubmit() {
+    const data = this.data.form
+    wx.request({
+      url: 'http://localhost:3000/orders',
+      method: 'POST',
+      data,
+      success: () => {
+        wx.showToast({ title: '订单创建成功' })
+        this.setData({
+          form: { customer: '', product: '', quantity: 1, amount: '' }
+        })
+      },
+      fail: () => {
+        wx.showToast({ title: '创建失败', icon: 'none' })
+      }
+    })
+  }
 })

--- a/miniprogram/pages/createOrder/index.wxml
+++ b/miniprogram/pages/createOrder/index.wxml
@@ -1,1 +1,19 @@
-<view>Create Order Page</view>
+<form bindsubmit="onSubmit">
+  <view class="form-item">
+    <text>客户</text>
+    <input data-field="customer" bindinput="onInput" placeholder="客户名称" value="{{form.customer}}" />
+  </view>
+  <view class="form-item">
+    <text>商品</text>
+    <input data-field="product" bindinput="onInput" placeholder="商品名称" value="{{form.product}}" />
+  </view>
+  <view class="form-item">
+    <text>数量</text>
+    <input data-field="quantity" bindinput="onInput" type="number" placeholder="数量" value="{{form.quantity}}" />
+  </view>
+  <view class="form-item">
+    <text>金额</text>
+    <input data-field="amount" bindinput="onInput" type="number" placeholder="金额" value="{{form.amount}}" />
+  </view>
+  <button formType="submit">提交</button>
+</form>

--- a/miniprogram/pages/orderList/index.js
+++ b/miniprogram/pages/orderList/index.js
@@ -1,4 +1,22 @@
 Page({
-  data: {},
-  onLoad(options) {}
+  data: {
+    orders: []
+  },
+
+  onLoad() {
+    this.fetchOrders()
+  },
+
+  fetchOrders() {
+    wx.request({
+      url: 'http://localhost:3000/orders',
+      method: 'GET',
+      success: (res) => {
+        this.setData({ orders: res.data })
+      },
+      fail: () => {
+        wx.showToast({ title: '加载失败', icon: 'none' })
+      }
+    })
+  }
 })

--- a/miniprogram/pages/orderList/index.wxml
+++ b/miniprogram/pages/orderList/index.wxml
@@ -1,1 +1,7 @@
-<view>Order List Page</view>
+<view>
+  <view wx:for="{{orders}}" wx:key="id" class="order-item">
+    <text>客户: {{item.Customer ? item.Customer.name : ''}}</text>
+    <text> 商品: {{item.Product ? item.Product.name : ''}}</text>
+    <text> 数量: {{item.quantity}}</text>
+  </view>
+</view>


### PR DESCRIPTION
## Summary
- add order creation form UI
- submit orders to backend
- load orders in order list page

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_684780b3426c833194ebad7e498669f4