### PR TITLE
Add order routes with seal & QR generation

### DIFF
--- a/server/routes/orders.js
+++ b/server/routes/orders.js
@@ -1,3 +1,45 @@
 const express = require('express');
 const router = express.Router();
-const { Order, Customer, Product } = require('../modex/研究并生成
+const { Order, Customer, Product } = require('../models');
+const generateSeal = require('../utils/sealGenerator');
+const generatePayCode = require('../utils/qrcode');
+
+// List all orders with associated customer and product
+router.get('/', async (req, res) => {
+  const orders = await Order.findAll({ include: [Customer, Product] });
+  res.json(orders);
+});
+
+// Get single order by id
+router.get('/:id', async (req, res) => {
+  const order = await Order.findByPk(req.params.id, { include: [Customer, Product] });
+  if (!order) return res.status(404).end();
+  res.json(order);
+});
+
+// Create a new order and attach seal/QR code
+router.post('/', async (req, res) => {
+  const order = await Order.create(req.body);
+  const seal = generateSeal(`Order ${order.id}`);
+  const payCode = await generatePayCode(`PAY:${order.id}`);
+  await order.update({ seal, payCode });
+  res.status(201).json(order);
+});
+
+// Update an order
+router.put('/:id', async (req, res) => {
+  const order = await Order.findByPk(req.params.id);
+  if (!order) return res.status(404).end();
+  await order.update(req.body);
+  res.json(order);
+});
+
+// Delete an order
+router.delete('/:id', async (req, res) => {
+  const order = await Order.findByPk(req.params.id);
+  if (!order) return res.status(404).end();
+  await order.destroy();
+  res.status(204).end();
+});
+
+module.exports = router;


### PR DESCRIPTION
## Summary
- recreate `server/routes/orders.js` file
- list orders with customer/product
- create orders with generated seal and payment QR code
- add standard read/update/delete endpoints

## Testing
- `npm install` *(fails: 403 Forbidden)*

------
https://chatgpt.com/codex/tasks/task_e_6847919216f08331809e79d8f736900c