### PR TITLE
Implement order creation and listing pages

### DIFF
--- a/miniprogram/pages/createOrder/index.js
+++ b/miniprogram/pages/createOrder/index.js
@@ -1,0 +1,56 @@
+Page({
+  data: {
+    products: [],
+    customers: [],
+    productIndex: 0,
+    customerIndex: 0,
+    quantity: 1
+  },
+
+  onLoad() {
+    wx.request({
+      url: 'http://localhost:3000/products',
+      success: res => {
+        this.setData({ products: res.data })
+      }
+    })
+    wx.request({
+      url: 'http://localhost:3000/customers',
+      success: res => {
+        this.setData({ customers: res.data })
+      }
+    })
+  },
+
+  onProductChange(e) {
+    this.setData({ productIndex: e.detail.value })
+  },
+
+  onCustomerChange(e) {
+    this.setData({ customerIndex: e.detail.value })
+  },
+
+  onQuantityChange(e) {
+    this.setData({ quantity: Number(e.detail.value) })
+  },
+
+  submitOrder() {
+    const { products, productIndex, customers, customerIndex, quantity } = this.data
+    const data = {
+      productId: products[productIndex] && products[productIndex].id,
+      customerId: customers[customerIndex] && customers[customerIndex].id,
+      quantity
+    }
+    wx.request({
+      url: 'http://localhost:3000/orders',
+      method: 'POST',
+      data,
+      success: res => {
+        const order = res.data
+        wx.navigateTo({
+          url: `/pages/orderDetail/index?id=${order.id}`
+        })
+      }
+    })
+  }
+})

--- a/miniprogram/pages/createOrder/index.wxml
+++ b/miniprogram/pages/createOrder/index.wxml
@@ -1,0 +1,16 @@
+<form bindsubmit="submitOrder">
+  <view class="field">
+    <picker mode="selector" range="{{products}}" range-key="name" value="{{productIndex}}" bindchange="onProductChange">
+      <view class="picker">{{products.length ? products[productIndex].name : '选择商品'}}</view>
+    </picker>
+  </view>
+  <view class="field">
+    <picker mode="selector" range="{{customers}}" range-key="name" value="{{customerIndex}}" bindchange="onCustomerChange">
+      <view class="picker">{{customers.length ? customers[customerIndex].name : '选择客户'}}</view>
+    </picker>
+  </view>
+  <view class="field">
+    <input type="number" value="{{quantity}}" bindinput="onQuantityChange" />
+  </view>
+  <button formType="submit" type="primary">提交订单</button>
+</form>

--- a/miniprogram/pages/createOrder/index.wxss
+++ b/miniprogram/pages/createOrder/index.wxss
@@ -1,1 +1,9 @@
 /* Create Order styles */
+.field {
+  margin: 16rpx 0;
+}
+
+.picker {
+  padding: 12rpx;
+  border: 1px solid #eee;
+}

--- a/miniprogram/pages/orderList/index.js
+++ b/miniprogram/pages/orderList/index.js
@@ -1,0 +1,25 @@
+Page({
+  data: {
+    orders: []
+  },
+
+  onLoad() {
+    this.fetchOrders()
+  },
+
+  fetchOrders() {
+    wx.request({
+      url: 'http://localhost:3000/orders',
+      success: res => {
+        this.setData({ orders: res.data })
+      }
+    })
+  },
+
+  goDetail(e) {
+    const id = e.currentTarget.dataset.id
+    wx.navigateTo({
+      url: `/pages/orderDetail/index?id=${id}`
+    })
+  }
+})

--- a/miniprogram/pages/orderList/index.wxml
+++ b/miniprogram/pages/orderList/index.wxml
@@ -1,0 +1,9 @@
+<view class="order-list">
+  <block wx:for="{{orders}}" wx:key="id">
+    <view class="order-item" data-id="{{item.id}}" bindtap="goDetail">
+      <view>订单编号：{{item.id}}</view>
+      <view>数量：{{item.quantity}}</view>
+      <view>状态：{{item.status}}</view>
+    </view>
+  </block>
+</view>


### PR DESCRIPTION
## Summary
- add order creation form with product & customer pickers
- load orders on order list page
- add simple navigation to order details

## Testing
- `npm test` *(fails: Could not read package.json)*
- `cd server && npm test` *(fails: Missing script: "test")*

------
https://chatgpt.com/codex/tasks/task_e_68479193350083319981d35922dfc7ac