### PR TITLE
Improve route error handling

### DIFF
--- a/server/routes/customers.js
+++ b/server/routes/customers.js
@@ -1,35 +1,51 @@
 const express = require('express');
 const router = express.Router();
 const { Customer } = require('../models');
+const asyncHandler = require('../utils/asyncHandler');
 
-router.get('/', async (req, res) => {
-  const customers = await Customer.findAll();
-  res.json(customers);
-});
+router.get(
+  '/',
+  asyncHandler(async (req, res) => {
+    const customers = await Customer.findAll();
+    res.json(customers);
+  })
+);
 
-router.get('/:id', async (req, res) => {
-  const customer = await Customer.findByPk(req.params.id);
-  if (!customer) return res.status(404).end();
-  res.json(customer);
-});
+router.get(
+  '/:id',
+  asyncHandler(async (req, res) => {
+    const customer = await Customer.findByPk(req.params.id);
+    if (!customer) return res.status(404).end();
+    res.json(customer);
+  })
+);
 
-router.post('/', async (req, res) => {
-  const customer = await Customer.create(req.body);
-  res.status(201).json(customer);
-});
+router.post(
+  '/',
+  asyncHandler(async (req, res) => {
+    const customer = await Customer.create(req.body);
+    res.status(201).json(customer);
+  })
+);
 
-router.put('/:id', async (req, res) => {
-  const customer = await Customer.findByPk(req.params.id);
-  if (!customer) return res.status(404).end();
-  await customer.update(req.body);
-  res.json(customer);
-});
+router.put(
+  '/:id',
+  asyncHandler(async (req, res) => {
+    const customer = await Customer.findByPk(req.params.id);
+    if (!customer) return res.status(404).end();
+    await customer.update(req.body);
+    res.json(customer);
+  })
+);
 
-router.delete('/:id', async (req, res) => {
-  const customer = await Customer.findByPk(req.params.id);
-  if (!customer) return res.status(404).end();
-  await customer.destroy();
-  res.status(204).end();
-});
+router.delete(
+  '/:id',
+  asyncHandler(async (req, res) => {
+    const customer = await Customer.findByPk(req.params.id);
+    if (!customer) return res.status(404).end();
+    await customer.destroy();
+    res.status(204).end();
+  })
+);
 
 module.exports = router;

--- a/server/routes/orders.js
+++ b/server/routes/orders.js
@@ -3,43 +3,59 @@ const router = express.Router();
 const { Order, Customer, Product } = require('../models');
 const generateSeal = require('../utils/sealGenerator');
 const generatePayCode = require('../utils/qrcode');
+const asyncHandler = require('../utils/asyncHandler');
 
 // List all orders with associated customer and product
-router.get('/', async (req, res) => {
-  const orders = await Order.findAll({ include: [Customer, Product] });
-  res.json(orders);
-});
+router.get(
+  '/',
+  asyncHandler(async (req, res) => {
+    const orders = await Order.findAll({ include: [Customer, Product] });
+    res.json(orders);
+  })
+);
 
 // Get single order by id
-router.get('/:id', async (req, res) => {
-  const order = await Order.findByPk(req.params.id, { include: [Customer, Product] });
-  if (!order) return res.status(404).end();
-  res.json(order);
-});
+router.get(
+  '/:id',
+  asyncHandler(async (req, res) => {
+    const order = await Order.findByPk(req.params.id, { include: [Customer, Product] });
+    if (!order) return res.status(404).end();
+    res.json(order);
+  })
+);
 
 // Create a new order and attach seal/QR code
-router.post('/', async (req, res) => {
-  const order = await Order.create(req.body);
-  const seal = generateSeal(`Order ${order.id}`);
-  const payCode = await generatePayCode(`PAY:${order.id}`);
-  await order.update({ seal, payCode });
-  res.status(201).json(order);
-});
+router.post(
+  '/',
+  asyncHandler(async (req, res) => {
+    const order = await Order.create(req.body);
+    const seal = generateSeal(`Order ${order.id}`);
+    const payCode = await generatePayCode(`PAY:${order.id}`);
+    await order.update({ seal, payCode });
+    res.status(201).json(order);
+  })
+);
 
 // Update an order
-router.put('/:id', async (req, res) => {
-  const order = await Order.findByPk(req.params.id);
-  if (!order) return res.status(404).end();
-  await order.update(req.body);
-  res.json(order);
-});
+router.put(
+  '/:id',
+  asyncHandler(async (req, res) => {
+    const order = await Order.findByPk(req.params.id);
+    if (!order) return res.status(404).end();
+    await order.update(req.body);
+    res.json(order);
+  })
+);
 
 // Delete an order
-router.delete('/:id', async (req, res) => {
-  const order = await Order.findByPk(req.params.id);
-  if (!order) return res.status(404).end();
-  await order.destroy();
-  res.status(204).end();
-});
+router.delete(
+  '/:id',
+  asyncHandler(async (req, res) => {
+    const order = await Order.findByPk(req.params.id);
+    if (!order) return res.status(404).end();
+    await order.destroy();
+    res.status(204).end();
+  })
+);
 
 module.exports = router;

--- a/server/routes/products.js
+++ b/server/routes/products.js
@@ -1,35 +1,51 @@
 const express = require('express');
 const router = express.Router();
 const { Product } = require('../models');
+const asyncHandler = require('../utils/asyncHandler');
 
-router.get('/', async (req, res) => {
-  const products = await Product.findAll();
-  res.json(products);
-});
+router.get(
+  '/',
+  asyncHandler(async (req, res) => {
+    const products = await Product.findAll();
+    res.json(products);
+  })
+);
 
-router.get('/:id', async (req, res) => {
-  const product = await Product.findByPk(req.params.id);
-  if (!product) return res.status(404).end();
-  res.json(product);
-});
+router.get(
+  '/:id',
+  asyncHandler(async (req, res) => {
+    const product = await Product.findByPk(req.params.id);
+    if (!product) return res.status(404).end();
+    res.json(product);
+  })
+);
 
-router.post('/', async (req, res) => {
-  const product = await Product.create(req.body);
-  res.status(201).json(product);
-});
+router.post(
+  '/',
+  asyncHandler(async (req, res) => {
+    const product = await Product.create(req.body);
+    res.status(201).json(product);
+  })
+);
 
-router.put('/:id', async (req, res) => {
-  const product = await Product.findByPk(req.params.id);
-  if (!product) return res.status(404).end();
-  await product.update(req.body);
-  res.json(product);
-});
+router.put(
+  '/:id',
+  asyncHandler(async (req, res) => {
+    const product = await Product.findByPk(req.params.id);
+    if (!product) return res.status(404).end();
+    await product.update(req.body);
+    res.json(product);
+  })
+);
 
-router.delete('/:id', async (req, res) => {
-  const product = await Product.findByPk(req.params.id);
-  if (!product) return res.status(404).end();
-  await product.destroy();
-  res.status(204).end();
-});
+router.delete(
+  '/:id',
+  asyncHandler(async (req, res) => {
+    const product = await Product.findByPk(req.params.id);
+    if (!product) return res.status(404).end();
+    await product.destroy();
+    res.status(204).end();
+  })
+);
 
 module.exports = router;

--- a/server/routes/wechat.js
+++ b/server/routes/wechat.js
@@ -2,45 +2,52 @@ const express = require('express');
 const router = express.Router();
 const crypto = require('crypto');
 const { Order } = require('../models');
+const asyncHandler = require('../utils/asyncHandler');
 
 // Generate a simulated prepay order
-router.post('/pay/preorder', async (req, res) => {
-  const { orderId } = req.body;
-  const order = await Order.findByPk(orderId);
-  if (!order) return res.status(404).json({ error: 'order not found' });
+router.post(
+  '/pay/preorder',
+  asyncHandler(async (req, res) => {
+    const { orderId } = req.body;
+    const order = await Order.findByPk(orderId);
+    if (!order) return res.status(404).json({ error: 'order not found' });
 
-  // In a real app here you would call WeChat unified order API
-  const prepayId = 'prepay_' + Date.now();
+    // In a real app here you would call WeChat unified order API
+    const prepayId = 'prepay_' + Date.now();
 
-  await order.update({ prepayId, payStatus: 'prepay' });
+    await order.update({ prepayId, payStatus: 'prepay' });
 
-  // Simulate params required by wx.requestPayment
-  const timeStamp = String(Math.floor(Date.now() / 1000));
-  const nonceStr = crypto.randomBytes(16).toString('hex');
-  const paySign = crypto
-    .createHash('md5')
-    .update(prepayId + timeStamp + nonceStr)
-    .digest('hex');
+    // Simulate params required by wx.requestPayment
+    const timeStamp = String(Math.floor(Date.now() / 1000));
+    const nonceStr = crypto.randomBytes(16).toString('hex');
+    const paySign = crypto
+      .createHash('md5')
+      .update(prepayId + timeStamp + nonceStr)
+      .digest('hex');
 
-  res.json({ prepayId, timeStamp, nonceStr, paySign });
-});
+    res.json({ prepayId, timeStamp, nonceStr, paySign });
+  })
+);
 
 // Simulated WeChat Pay callback handler
-router.post('/pay/callback', async (req, res) => {
-  console.log('Received WeChat Pay callback:', req.body);
-  const { orderId, signature } = req.body;
-  const order = await Order.findByPk(orderId);
-  if (!order) return res.status(404).end();
+router.post(
+  '/pay/callback',
+  asyncHandler(async (req, res) => {
+    console.log('Received WeChat Pay callback:', req.body);
+    const { orderId, signature } = req.body;
+    const order = await Order.findByPk(orderId);
+    if (!order) return res.status(404).end();
 
-  // Here you would verify the signature using WeChat's algorithm
-  const expected = crypto
-    .createHash('md5')
-    .update(order.prepayId)
-    .digest('hex');
-  if (signature !== expected) return res.status(400).end();
+    // Here you would verify the signature using WeChat's algorithm
+    const expected = crypto
+      .createHash('md5')
+      .update(order.prepayId)
+      .digest('hex');
+    if (signature !== expected) return res.status(400).end();
 
-  await order.update({ payStatus: 'paid', status: 'paid' });
-  res.send('success');
-});
+    await order.update({ payStatus: 'paid', status: 'paid' });
+    res.send('success');
+  })
+);
 
 module.exports = router;

--- a/server/utils/asyncHandler.js
+++ b/server/utils/asyncHandler.js
@@ -1,0 +1,12 @@
+function asyncHandler(fn) {
+  return async function(req, res, next) {
+    try {
+      await fn(req, res, next);
+    } catch (err) {
+      console.error(err);
+      res.status(500).json({ error: 'Internal server error' });
+    }
+  };
+}
+
+module.exports = asyncHandler;


### PR DESCRIPTION
## Summary
- add async handler helper for consistent try/catch
- wrap all async routes with helper

## Testing
- `npm test` *(fails: Missing script)*
- `npm start` *(fails: Cannot find module 'express')*

------
https://chatgpt.com/codex/tasks/task_e_6847934b09148331a4c65cb5919479c3