### PR TITLE
Implement order detail page and API config

### DIFF
--- a/README.md
+++ b/README.md
@@ -19,4 +19,5 @@
 ## 运行
 
 1. 进入 `server` 目录执行 `npm install && npm start` 启动接口服务。
-2. 使用微信开发者工具打开 `miniprogram` 目录即可预览小程序。
+2. 根据需要修改 `miniprogram/utils/config.js` 中的 `baseUrl`，指向后端接口地址。
+3. 使用微信开发者工具打开 `miniprogram` 目录即可预览小程序。

--- a/miniprogram/pages/createOrder/index.js
+++ b/miniprogram/pages/createOrder/index.js
@@ -1,3 +1,5 @@
+const { baseUrl } = require('../../utils/config')
+
 Page({
   data: {
     products: [],
@@ -9,13 +11,13 @@ Page({
 
   onLoad() {
     wx.request({
-      url: 'http://localhost:3000/products',
+      url: `${baseUrl}/products`,
       success: res => {
         this.setData({ products: res.data })
       }
     })
     wx.request({
-      url: 'http://localhost:3000/customers',
+      url: `${baseUrl}/customers`,
       success: res => {
         this.setData({ customers: res.data })
       }
@@ -42,7 +44,7 @@ Page({
       quantity
     }
     wx.request({
-      url: 'http://localhost:3000/orders',
+      url: `${baseUrl}/orders`,
       method: 'POST',
       data,
       success: res => {

--- a/miniprogram/pages/orderDetail/index.js
+++ b/miniprogram/pages/orderDetail/index.js
@@ -1,0 +1,33 @@
+const { baseUrl } = require('../../utils/config')
+
+Page({
+  data: {
+    order: null
+  },
+
+  onLoad(options) {
+    const { id } = options
+    if (id) {
+      this.fetchOrder(id)
+    }
+  },
+
+  fetchOrder(id) {
+    wx.request({
+      url: `${baseUrl}/orders/${id}`,
+      success: res => {
+        this.setData({ order: res.data })
+      }
+    })
+  },
+
+  onShareAppMessage() {
+    const { order } = this.data
+    if (!order) return {}
+    return {
+      title: `订单 ${order.id}`,
+      path: `/pages/orderDetail/index?id=${order.id}`,
+      imageUrl: order.seal || ''
+    }
+  }
+})

--- a/miniprogram/pages/orderDetail/index.wxml
+++ b/miniprogram/pages/orderDetail/index.wxml
@@ -1,0 +1,10 @@
+<view wx:if="{{order}}" class="order-detail">
+  <view>订单编号：{{order.id}}</view>
+  <view>客户：{{order.Customer.name}}</view>
+  <view>商品：{{order.Product.name}}</view>
+  <view>数量：{{order.quantity}}</view>
+  <view>状态：{{order.status}}</view>
+  <image wx:if="{{order.seal}}" src="{{order.seal}}" mode="widthFix" class="seal" />
+  <image wx:if="{{order.payCode}}" src="{{order.payCode}}" mode="widthFix" class="qrcode" />
+  <button open-type="share" type="primary">分享订单</button>
+</view>

--- a/miniprogram/pages/orderDetail/index.wxss
+++ b/miniprogram/pages/orderDetail/index.wxss
@@ -1,1 +1,9 @@
-/* Order Detail styles */
+.order-detail {
+  padding: 16rpx;
+}
+
+.seal,
+.qrcode {
+  width: 200rpx;
+  margin: 16rpx 0;
+}

--- a/miniprogram/pages/orderList/index.js
+++ b/miniprogram/pages/orderList/index.js
@@ -1,3 +1,5 @@
+const { baseUrl } = require('../../utils/config')
+
 Page({
   data: {
     orders: []
@@ -9,7 +11,7 @@ Page({
 
   fetchOrders() {
     wx.request({
-      url: 'http://localhost:3000/orders',
+      url: `${baseUrl}/orders`,
       success: res => {
         this.setData({ orders: res.data })
       }

--- a/miniprogram/utils/config.js
+++ b/miniprogram/utils/config.js
@@ -1,0 +1,5 @@
+const baseUrl = 'http://localhost:3000'
+
+module.exports = {
+  baseUrl,
+}

--- a/server/index.js
+++ b/server/index.js
@@ -17,6 +17,11 @@ app.use('/products', productRoutes);
 app.use('/orders', orderRoutes);
 app.use('/wechat', wechatRoutes);
 
+app.use((err, req, res, next) => {
+  console.error(err)
+  res.status(500).json({ error: 'Internal server error' })
+})
+
 const port = process.env.PORT || 3000;
 
 async function start() {

--- a/server/utils/asyncHandler.js
+++ b/server/utils/asyncHandler.js
@@ -1,10 +1,9 @@
 function asyncHandler(fn) {
-  return async function(req, res, next) {
+  return async function (req, res, next) {
     try {
       await fn(req, res, next);
     } catch (err) {
-      console.error(err);
-      res.status(500).json({ error: 'Internal server error' });
+      next(err);
     }
   };
 }


### PR DESCRIPTION
## Summary
- implement missing order detail mini-program page with share feature
- centralize API base URL in new `miniprogram/utils/config.js`
- update order creation and list pages to use the new config
- improve Express async handler and add global error middleware
- document base URL config in README

## Testing
- `npm test` *(fails: Missing script)*

------
https://chatgpt.com/codex/tasks/task_e_6847956c175883319a19c3e4ec6ac7da