### PR TITLE
Add order editing and deletion

### DIFF
--- a/miniprogram/app.json
+++ b/miniprogram/app.json
@@ -2,6 +2,7 @@
   "pages": [
     "pages/createOrder/index",
     "pages/orderList/index",
+    "pages/editOrder/index",
     "pages/orderDetail/index"
   ],
   "window": {

--- a/miniprogram/pages/editOrder/index.js
+++ b/miniprogram/pages/editOrder/index.js
@@ -1,0 +1,90 @@
+const { baseUrl } = require('../../utils/config')
+
+Page({
+  data: {
+    products: [],
+    customers: [],
+    productIndex: 0,
+    customerIndex: 0,
+    quantity: 1,
+    orderId: null,
+  },
+
+  onLoad(options) {
+    const { id } = options
+    if (id) {
+      this.setData({ orderId: id })
+      this.loadOrder(id)
+    }
+  },
+
+  loadOrder(id) {
+    wx.request({
+      url: `${baseUrl}/orders/${id}`,
+      success: res => {
+        const order = res.data
+        this.setData({ quantity: order.quantity })
+        this.loadLists(order)
+      }
+    })
+  },
+
+  loadLists(order) {
+    wx.request({
+      url: `${baseUrl}/products`,
+      success: res => {
+        const products = res.data
+        const productId = order.Product ? order.Product.id : order.productId
+        const productIndex = products.findIndex(p => p.id === productId)
+        this.setData({
+          products,
+          productIndex: productIndex >= 0 ? productIndex : 0
+        })
+      }
+    })
+    wx.request({
+      url: `${baseUrl}/customers`,
+      success: res => {
+        const customers = res.data
+        const customerId = order.Customer ? order.Customer.id : order.customerId
+        const customerIndex = customers.findIndex(c => c.id === customerId)
+        this.setData({
+          customers,
+          customerIndex: customerIndex >= 0 ? customerIndex : 0
+        })
+      }
+    })
+  },
+
+  onProductChange(e) {
+    this.setData({ productIndex: e.detail.value })
+  },
+
+  onCustomerChange(e) {
+    this.setData({ customerIndex: e.detail.value })
+  },
+
+  onQuantityChange(e) {
+    this.setData({ quantity: Number(e.detail.value) })
+  },
+
+  submitOrder() {
+    const { orderId, products, productIndex, customers, customerIndex, quantity } = this.data
+    const data = {
+      productId: products[productIndex] && products[productIndex].id,
+      customerId: customers[customerIndex] && customers[customerIndex].id,
+      quantity
+    }
+    wx.request({
+      url: `${baseUrl}/orders/${orderId}`,
+      method: 'PUT',
+      data,
+      success: res => {
+        const order = res.data
+        wx.redirectTo({
+          url: `/pages/orderDetail/index?id=${order.id}`
+        })
+      }
+    })
+  }
+})

--- a/miniprogram/pages/editOrder/index.wxml
+++ b/miniprogram/pages/editOrder/index.wxml
@@ -1,0 +1,16 @@
+<form bindsubmit="submitOrder">
+  <view class="field">
+    <picker mode="selector" range="{{products}}" range-key="name" value="{{productIndex}}" bindchange="onProductChange">
+      <view class="picker">{{products.length ? products[productIndex].name : '选择商品'}}</view>
+    </picker>
+  </view>
+  <view class="field">
+    <picker mode="selector" range="{{customers}}" range-key="name" value="{{customerIndex}}" bindchange="onCustomerChange">
+      <view class="picker">{{customers.length ? customers[customerIndex].name : '选择客户'}}</view>
+    </picker>
+  </view>
+  <view class="field">
+    <input type="number" value="{{quantity}}" bindinput="onQuantityChange" />
+  </view>
+  <button formType="submit" type="primary">保存订单</button>
+</form>

--- a/miniprogram/pages/editOrder/index.wxss
+++ b/miniprogram/pages/editOrder/index.wxss
@@ -1,0 +1,9 @@
+/* Create Order styles */
+.field {
+  margin: 16rpx 0;
+}
+
+.picker {
+  padding: 12rpx;
+  border: 1px solid #eee;
+}

--- a/miniprogram/pages/orderDetail/index.js
+++ b/miniprogram/pages/orderDetail/index.js
@@ -21,6 +21,36 @@ Page({
     })
   },
 
+  editOrder() {
+    const { order } = this.data
+    if (!order) return
+    wx.navigateTo({
+      url: `/pages/editOrder/index?id=${order.id}`
+    })
+  },
+
+  deleteOrder() {
+    const { order } = this.data
+    if (!order) return
+    wx.showModal({
+      title: '删除确认',
+      content: '确定要删除该订单吗？',
+      success: res => {
+        if (res.confirm) {
+          wx.request({
+            url: `${baseUrl}/orders/${order.id}`,
+            method: 'DELETE',
+            success: () => {
+              wx.redirectTo({
+                url: '/pages/orderList/index'
+              })
+            }
+          })
+        }
+      }
+    })
+  },
+
   onShareAppMessage() {
     const { order } = this.data
     if (!order) return {}

--- a/miniprogram/pages/orderDetail/index.wxml
+++ b/miniprogram/pages/orderDetail/index.wxml
@@ -7,4 +7,6 @@
   <image wx:if="{{order.seal}}" src="{{order.seal}}" mode="widthFix" class="seal" />
   <image wx:if="{{order.payCode}}" src="{{order.payCode}}" mode="widthFix" class="qrcode" />
   <button open-type="share" type="primary">分享订单</button>
+  <button type="default" bindtap="editOrder">编辑订单</button>
+  <button type="warn" bindtap="deleteOrder">删除订单</button>
 </view>

--- a/miniprogram/pages/orderList/index.js
+++ b/miniprogram/pages/orderList/index.js
@@ -23,5 +23,31 @@ Page({
     wx.navigateTo({
       url: `/pages/orderDetail/index?id=${id}`
     })
+  },
+
+  editOrder(e) {
+    const id = e.currentTarget.dataset.id
+    wx.navigateTo({
+      url: `/pages/editOrder/index?id=${id}`
+    })
+  },
+
+  deleteOrder(e) {
+    const id = e.currentTarget.dataset.id
+    wx.showModal({
+      title: '删除确认',
+      content: '确定要删除该订单吗？',
+      success: res => {
+        if (res.confirm) {
+          wx.request({
+            url: `${baseUrl}/orders/${id}`,
+            method: 'DELETE',
+            success: () => {
+              this.fetchOrders()
+            }
+          })
+        }
+      }
+    })
   }
 })

--- a/miniprogram/pages/orderList/index.wxml
+++ b/miniprogram/pages/orderList/index.wxml
@@ -1,9 +1,15 @@
 <view class="order-list">
   <block wx:for="{{orders}}" wx:key="id">
-    <view class="order-item" data-id="{{item.id}}" bindtap="goDetail">
-      <view>订单编号：{{item.id}}</view>
-      <view>数量：{{item.quantity}}</view>
-      <view>状态：{{item.status}}</view>
+    <view class="order-item">
+      <view data-id="{{item.id}}" bindtap="goDetail">
+        <view>订单编号：{{item.id}}</view>
+        <view>数量：{{item.quantity}}</view>
+        <view>状态：{{item.status}}</view>
+      </view>
+      <view class="actions">
+        <button size="mini" data-id="{{item.id}}" bindtap="editOrder">编辑</button>
+        <button size="mini" type="warn" data-id="{{item.id}}" bindtap="deleteOrder">删除</button>
+      </view>
     </view>
   </block>
 </view>

--- a/miniprogram/pages/orderList/index.wxss
+++ b/miniprogram/pages/orderList/index.wxss
@@ -11,3 +11,7 @@
   border-bottom: 1px solid #eee;
   padding-bottom: 8rpx;
 }
+
+.actions {
+  margin-top: 8rpx;
+}


### PR DESCRIPTION
## Summary
- add Edit Order page for modifying existing orders
- expose edit & delete actions from order list
- allow editing & deleting on order detail page
- register new page in app configuration

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68479eb8cde483318a24ea5055aacdec