### PR TITLE
Add Jest tests for server CRUD APIs

### DIFF
--- a/server/app.js
+++ b/server/app.js
@@ -1,0 +1,24 @@
+const express = require('express');
+const bodyParser = require('body-parser');
+const cors = require('cors');
+
+const customerRoutes = require('./routes/customers');
+const productRoutes = require('./routes/products');
+const orderRoutes = require('./routes/orders');
+const wechatRoutes = require('./routes/wechat');
+
+const app = express();
+app.use(bodyParser.json());
+app.use(cors());
+
+app.use('/customers', customerRoutes);
+app.use('/products', productRoutes);
+app.use('/orders', orderRoutes);
+app.use('/wechat', wechatRoutes);
+
+app.use((err, req, res, next) => {
+  console.error(err);
+  res.status(500).json({ error: 'Internal server error' });
+});
+
+module.exports = app;

--- a/server/index.js
+++ b/server/index.js
@@ -1,26 +1,5 @@
-const express = require('express');
-const bodyParser = require('body-parser');
-const cors = require('cors');
-
 const { sequelize } = require('./models');
-const customerRoutes = require('./routes/customers');
-const productRoutes = require('./routes/products');
-const orderRoutes = require('./routes/orders');
-const wechatRoutes = require('./routes/wechat');
-
-const app = express();
-app.use(bodyParser.json());
-app.use(cors());
-
-app.use('/customers', customerRoutes);
-app.use('/products', productRoutes);
-app.use('/orders', orderRoutes);
-app.use('/wechat', wechatRoutes);
-
-app.use((err, req, res, next) => {
-  console.error(err)
-  res.status(500).json({ error: 'Internal server error' })
-})
+const app = require('./app');
 
 const port = process.env.PORT || 3000;
 

--- a/server/jest.config.js
+++ b/server/jest.config.js
@@ -1,0 +1,4 @@
+module.exports = {
+  testEnvironment: 'node',
+  testMatch: ['**/tests/**/*.test.js']
+};

--- a/server/package.json
+++ b/server/package.json
@@ -5,7 +5,7 @@
   "main": "index.js",
   "scripts": {
     "start": "node index.js",
-    "test": "echo \"No tests defined\""
+    "test": "jest"
   },
   "dependencies": {
     "express": "^4.18.2",
@@ -15,5 +15,9 @@
     "canvas": "^2.11.2",
     "qrcode": "^1.5.1",
     "cors": "^2.8.5"
+  },
+  "devDependencies": {
+    "jest": "^29.6.1",
+    "supertest": "^6.3.3"
   }
 }

--- a/server/tests/api.test.js
+++ b/server/tests/api.test.js
@@ -1,0 +1,104 @@
+const request = require('supertest');
+jest.mock("../utils/sealGenerator", () => jest.fn(() => "SEAL"));
+jest.mock("../utils/qrcode", () => jest.fn(async () => "QRCODE"));
+
+
+process.env.MYSQL_URI = 'sqlite::memory:';
+const app = require('../app');
+const { sequelize, Customer, Product } = require('../models');
+
+beforeAll(async () => {
+  await sequelize.sync();
+});
+
+beforeEach(async () => {
+  await sequelize.truncate({ cascade: true });
+});
+
+afterAll(async () => {
+  await sequelize.close();
+});
+
+describe('Customer CRUD', () => {
+  test('create, read, update and delete', async () => {
+    let res = await request(app)
+      .post('/customers')
+      .send({ name: 'John', email: 'john@example.com' });
+    expect(res.status).toBe(201);
+    const id = res.body.id;
+
+    res = await request(app).get(`/customers/${id}`);
+    expect(res.status).toBe(200);
+    expect(res.body.email).toBe('john@example.com');
+
+    res = await request(app)
+      .put(`/customers/${id}`)
+      .send({ name: 'Johnny' });
+    expect(res.status).toBe(200);
+    expect(res.body.name).toBe('Johnny');
+
+    res = await request(app).delete(`/customers/${id}`);
+    expect(res.status).toBe(204);
+  });
+});
+
+describe('Product CRUD', () => {
+  test('create, read, update and delete', async () => {
+    let res = await request(app)
+      .post('/products')
+      .send({ name: 'Widget', price: 9.99 });
+    expect(res.status).toBe(201);
+    const id = res.body.id;
+
+    res = await request(app).get(`/products/${id}`);
+    expect(res.status).toBe(200);
+    expect(res.body.price).toBe('9.99');
+
+    res = await request(app)
+      .put(`/products/${id}`)
+      .send({ price: 19.99 });
+    expect(res.status).toBe(200);
+    expect(res.body.price).toBe('19.99');
+
+    res = await request(app).delete(`/products/${id}`);
+    expect(res.status).toBe(204);
+  });
+});
+
+describe('Order CRUD', () => {
+  beforeEach(async () => {
+    await sequelize.truncate({ cascade: true });
+  });
+
+  test('create, read, update and delete', async () => {
+    const customer = await Customer.create({
+      name: 'Alice',
+      email: 'alice@example.com',
+    });
+    const product = await Product.create({ name: 'Gadget', price: 5 });
+
+    let res = await request(app)
+      .post('/orders')
+      .send({
+        CustomerId: customer.id,
+        ProductId: product.id,
+        quantity: 2,
+      });
+    expect(res.status).toBe(201);
+    const id = res.body.id;
+
+    res = await request(app).get(`/orders/${id}`);
+    expect(res.status).toBe(200);
+    expect(res.body.CustomerId).toBe(customer.id);
+    expect(res.body.ProductId).toBe(product.id);
+
+    res = await request(app)
+      .put(`/orders/${id}`)
+      .send({ quantity: 3 });
+    expect(res.status).toBe(200);
+    expect(res.body.quantity).toBe(3);
+
+    res = await request(app).delete(`/orders/${id}`);
+    expect(res.status).toBe(204);
+  });
+});


### PR DESCRIPTION
## Summary
- add reusable Express app in `server/app.js`
- update `index.js` to use the new app
- install Jest and Supertest and configure jest
- write CRUD route tests for customers, products and orders

## Testing
- `npm test` *(fails: jest not found)*

------
https://chatgpt.com/codex/tasks/task_e_68479eb9e988833187bb21a68934a149