### PR TITLE
Integrate WeChat pay

### DIFF
--- a/miniprogram/pages/orderDetail/index.js
+++ b/miniprogram/pages/orderDetail/index.js
@@ -51,6 +51,37 @@ Page({
     })
   },
 
+  payOrder() {
+    const { order } = this.data
+    if (!order) return
+    wx.request({
+      url: `${baseUrl}/wechat/pay/preorder`,
+      method: 'POST',
+      data: { orderId: order.id },
+      success: res => {
+        const params = res.data || {}
+        wx.requestPayment({
+          timeStamp: params.timeStamp,
+          nonceStr: params.nonceStr,
+          package: params.package,
+          signType: params.signType,
+          paySign: params.paySign,
+          success: () => {
+            wx.showToast({ title: '支付成功' })
+            this.fetchOrder(order.id)
+          },
+          fail: () => {
+            wx.showToast({ icon: 'none', title: '支付失败' })
+            this.fetchOrder(order.id)
+          }
+        })
+      },
+      fail: () => {
+        wx.showToast({ icon: 'none', title: '下单失败' })
+      }
+    })
+  },
+
   onShareAppMessage() {
     const { order } = this.data
     if (!order) return {}

--- a/miniprogram/pages/orderDetail/index.wxml
+++ b/miniprogram/pages/orderDetail/index.wxml
@@ -6,6 +6,7 @@
   <view>状态：{{order.status}}</view>
   <image wx:if="{{order.seal}}" src="{{order.seal}}" mode="widthFix" class="seal" />
   <image wx:if="{{order.payCode}}" src="{{order.payCode}}" mode="widthFix" class="qrcode" />
+  <button wx:if="{{order.payStatus !== 'paid'}}" type="primary" bindtap="payOrder">立即支付</button>
   <button open-type="share" type="primary">分享订单</button>
   <button type="default" bindtap="editOrder">编辑订单</button>
   <button type="warn" bindtap="deleteOrder">删除订单</button>

--- a/server/package.json
+++ b/server/package.json
@@ -15,7 +15,7 @@
     "canvas": "^2.11.2",
     "qrcode": "^1.5.1",
     "axios": "^1.6.7",
-    "xml2js": "^0.6.2",
+    "xml2js": "^0.6.2"
   },
   "devDependencies": {
     "jest": "^29.7.0",

--- a/server/routes/wechat.js
+++ b/server/routes/wechat.js
@@ -114,16 +114,22 @@ router.post(
     delete data.sign;
     const expected = buildSign(data);
     if (sign !== expected) {
-      return res.send(buildXML({ return_code: 'FAIL', return_msg: 'SIGNERROR' }));
+      const xmlRes = buildXML({ return_code: 'FAIL', return_msg: 'SIGNERROR' });
+      if (req.accepts('json')) return res.status(400).json({ success: false });
+      return res.send(xmlRes);
     }
 
     const order = await Order.findByPk(data.out_trade_no);
     if (!order) {
-      return res.send(buildXML({ return_code: 'FAIL', return_msg: 'ORDERNOTFOUND' }));
+      const xmlRes = buildXML({ return_code: 'FAIL', return_msg: 'ORDERNOTFOUND' });
+      if (req.accepts('json')) return res.status(404).json({ success: false });
+      return res.send(xmlRes);
     }
 
     await order.update({ payStatus: 'paid', status: 'paid' });
-    res.send(buildXML({ return_code: 'SUCCESS', return_msg: 'OK' }));
+    const xmlRes = buildXML({ return_code: 'SUCCESS', return_msg: 'OK' });
+    if (req.accepts('json')) return res.json({ success: true });
+    res.send(xmlRes);
   })
 );
 


### PR DESCRIPTION
## Summary
- show a pay button on order detail page
- allow paying via `/wechat/pay/preorder` and `wx.requestPayment`
- return JSON when `/wechat/pay/callback` is accessed by the app
- fix server package.json JSON syntax

## Testing
- `npm test` *(fails: jest not found)*

------
https://chatgpt.com/codex/tasks/task_e_6847f99d0dac8331b5e05393eb845af5